### PR TITLE
Fix recursvie let terms in the term parser

### DIFF
--- a/src/main/java/gov/nasa/jpf/constraints/solvers/smtinterpol/SMTInterpolSolver.java
+++ b/src/main/java/gov/nasa/jpf/constraints/solvers/smtinterpol/SMTInterpolSolver.java
@@ -24,6 +24,7 @@ import gov.nasa.jpf.constraints.api.Expression;
 import gov.nasa.jpf.constraints.api.InterpolationSolver;
 import gov.nasa.jpf.constraints.api.Valuation;
 import gov.nasa.jpf.constraints.api.Variable;
+import gov.nasa.jpf.constraints.solvers.smtinterpol.exception.TermParserException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -84,7 +85,14 @@ public class SMTInterpolSolver extends ConstraintSolver implements Interpolation
             for (Term t : interpolants) {
                 //System.out.println(t);
                 TermParser parser = new TermParser(t, gen.getVariables());
-                Expression<Boolean> interpolant = parser.parse();
+                Expression<Boolean> interpolant;
+              try {
+                interpolant = parser.parse();
+              } catch (TermParserException ex) {
+                Logger.getLogger(SMTInterpolSolver.class.getName())
+                        .log(java.util.logging.Level.SEVERE, null, ex);
+                return null;
+              }
                 ret.add(interpolant);
             }
             

--- a/src/main/java/gov/nasa/jpf/constraints/solvers/smtinterpol/TermParser.java
+++ b/src/main/java/gov/nasa/jpf/constraints/solvers/smtinterpol/TermParser.java
@@ -25,6 +25,7 @@ import gov.nasa.jpf.constraints.expressions.NumericComparator;
 import gov.nasa.jpf.constraints.expressions.NumericCompound;
 import gov.nasa.jpf.constraints.expressions.NumericOperator;
 import gov.nasa.jpf.constraints.expressions.UnaryMinus;
+import gov.nasa.jpf.constraints.solvers.smtinterpol.exception.TermParserException;
 import gov.nasa.jpf.constraints.types.BuiltinTypes;
 import gov.nasa.jpf.constraints.util.ExpressionUtil;
 import java.util.ArrayList;
@@ -47,7 +48,7 @@ public class TermParser {
         }
     }
 
-    public Expression parse() {
+    public Expression parse() throws TermParserException {
         parseLet();
         Expression result = parseTerm();
         return result;
@@ -154,13 +155,13 @@ public class TermParser {
         input = input.trim();
     }
 
-    private void parseLet() {
+    private void parseLet() throws TermParserException {
       while (hasMoreLet()) {
-            getFirstLet();
-        }
+        getFirstLet();
+      }
     }
 
-    private void parseOneLet() {
+    private void parseOneLet() throws TermParserException {
         trim();
         this.input = this.input.replaceFirst("\\(let", "");
         trim();
@@ -187,7 +188,7 @@ public class TermParser {
         return this.input.contains("(let");
     }
 
-    private void getFirstLet() {
+    private void getFirstLet() throws TermParserException {
         int idx = this.input.indexOf("(let");
         String prefix = this.input.substring(0, idx);
         this.input = this.input.substring(idx);
@@ -196,18 +197,20 @@ public class TermParser {
         this.input = prefix + this.input + postfix;
     }
 
-    private String preparePostfix(){
+    private String preparePostfix() throws TermParserException{
         int endIdx = getEndOfLetTerm(this.input, 5,0)+1;
         String postfix = this.input.substring(endIdx);
         postfix = postfix.trim();
         this.input = this.input.substring(0,endIdx);
-        //In case this was not the last let in the term, we need to remove the closing bracket.
+        //In case this was not the last let in the term,
+        //we need to remove the closing bracket.
         endIdx = getEndOfLetTerm(postfix, 0,-1);
         postfix = postfix.substring(0,endIdx) + postfix.substring(endIdx+1);
         return postfix;
     }
 
-    private int getEndOfLetTerm(String analysisPart, int start, int breakCondition){
+    private int getEndOfLetTerm(String analysisPart, 
+            int start, int breakCondition) throws TermParserException{
         int open = 0;
         int closed = 0;
         char[] inputs = analysisPart.toCharArray();
@@ -224,8 +227,6 @@ public class TermParser {
             return index;
           }
         }
-        System.err.println("Cannot fin the end of the let term");
-        System.exit(42);
-        return -1;
+        throw new TermParserException("Cannot find the end of the let term");
     }
 }

--- a/src/main/java/gov/nasa/jpf/constraints/solvers/smtinterpol/TermParser.java
+++ b/src/main/java/gov/nasa/jpf/constraints/solvers/smtinterpol/TermParser.java
@@ -206,6 +206,7 @@ public class TermParser {
         postfix = postfix.substring(0,endIdx) + postfix.substring(endIdx+1);
         return postfix;
     }
+
     private int getEndOfLetTerm(String analysisPart, int start, int breakCondition){
         int open = 0;
         int closed = 0;
@@ -226,9 +227,5 @@ public class TermParser {
         System.err.println("Cannot fin the end of the let term");
         System.exit(42);
         return -1;
-    }
-
-    private boolean isLetTerm() {
-      return this.input.startsWith("(Let");
     }
 }

--- a/src/main/java/gov/nasa/jpf/constraints/solvers/smtinterpol/exception/TermParserException.java
+++ b/src/main/java/gov/nasa/jpf/constraints/solvers/smtinterpol/exception/TermParserException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015, United States Government, as represented by the 
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The PSYCO: A Predicate-based Symbolic Compositional Reasoning environment 
+ * platform is licensed under the Apache License, Version 2.0 (the "License"); you 
+ * may not use this file except in compliance with the License. You may obtain a 
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0. 
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed 
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+ * specific language governing permissions and limitations under the License.
+ */
+package gov.nasa.jpf.constraints.solvers.smtinterpol.exception;
+
+
+public class TermParserException extends Exception {
+
+  public TermParserException() {
+  }
+
+  public TermParserException(String msg) {
+    super(msg);
+  }
+}


### PR DESCRIPTION
There was a problem in the term parser for recursive let parsing. A let clause inside a let clause is allowed in the SMT standard, but was not supported by the term parser. The proposed bug fixes enhances the term parser regarding parsing of recursive let definitions.
