### PR TITLE
Controlling smtinterpol commandline output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compiler-plugin.version>3.1</compiler-plugin.version>
-        <interpol.version>2.1</interpol.version>
+        <interpol.version>2.5</interpol.version>
         <testng.version>6.8</testng.version>
         <jconstraints.version>0.9.2-SNAPSHOT</jconstraints.version>		
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compiler-plugin.version>3.1</compiler-plugin.version>
-        <interpol.version>2.0</interpol.version>
+        <interpol.version>2.1</interpol.version>
         <testng.version>6.8</testng.version>
         <jconstraints.version>0.9.2-SNAPSHOT</jconstraints.version>		
     </properties>

--- a/src/main/java/gov/nasa/jpf/constraints/solvers/smtinterpol/SMTInterpolSolver.java
+++ b/src/main/java/gov/nasa/jpf/constraints/solvers/smtinterpol/SMTInterpolSolver.java
@@ -19,6 +19,7 @@ import de.uni_freiburg.informatik.ultimate.logic.Annotation;
 import de.uni_freiburg.informatik.ultimate.logic.Logics;
 import de.uni_freiburg.informatik.ultimate.logic.Script;
 import de.uni_freiburg.informatik.ultimate.logic.Term;
+import static de.uni_freiburg.informatik.ultimate.smtinterpol.LogProxy.LOGLEVEL_ERROR;
 import gov.nasa.jpf.constraints.api.ConstraintSolver;
 import gov.nasa.jpf.constraints.api.Expression;
 import gov.nasa.jpf.constraints.api.InterpolationSolver;
@@ -48,6 +49,8 @@ public class SMTInterpolSolver extends ConstraintSolver implements Interpolation
         ArrayList<String> names = new ArrayList<>();
 
         s.setOption(":produce-interpolants", true);
+        //This might be change, if you need internal output from smtinterpol for debugging.
+        s.setOption(":verbosity", LOGLEVEL_ERROR);
         s.setLogic(Logics.QF_LIA);
         int i = 1;
         for (Expression<Boolean> e : exprsn) {            

--- a/src/test/java/gov/nasa/jpf/constraints/solvers/smtinterpol/SMTInterpolTest.java
+++ b/src/test/java/gov/nasa/jpf/constraints/solvers/smtinterpol/SMTInterpolTest.java
@@ -15,7 +15,6 @@
  */
 package gov.nasa.jpf.constraints.solvers.smtinterpol;
 
-import gov.nasa.jpf.constraints.solvers.smtinterpol.SMTInterpolSolver;
 import de.uni_freiburg.informatik.ultimate.logic.Annotation;
 import de.uni_freiburg.informatik.ultimate.logic.Logics;
 import de.uni_freiburg.informatik.ultimate.logic.SMTLIBException;
@@ -23,6 +22,7 @@ import de.uni_freiburg.informatik.ultimate.logic.Script;
 import de.uni_freiburg.informatik.ultimate.logic.Script.LBool;
 import de.uni_freiburg.informatik.ultimate.logic.Sort;
 import de.uni_freiburg.informatik.ultimate.logic.Term;
+import static de.uni_freiburg.informatik.ultimate.smtinterpol.LogProxy.LOGLEVEL_ERROR;
 import de.uni_freiburg.informatik.ultimate.smtinterpol.smtlib2.SMTInterpol;
 import gov.nasa.jpf.constraints.api.Expression;
 import gov.nasa.jpf.constraints.api.Variable;
@@ -36,7 +36,6 @@ import gov.nasa.jpf.constraints.util.ExpressionUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import junit.framework.TestCase;
 
 import org.testng.annotations.Test;
 
@@ -46,12 +45,9 @@ public class SMTInterpolTest {
     public void test1() {
         System.out.println("--- test 1");
         try {
-            de.uni_freiburg.informatik.ultimate.smtinterpol.
-                    DefaultLogger smtLogger = 
-                        new de.uni_freiburg.informatik.ultimate.smtinterpol
-                          .DefaultLogger();
-            Script s = new SMTInterpol(smtLogger, true);
+            Script s = new SMTInterpol();
             s.setOption(":produce-interpolants", true);
+            s.setOption(":verbosity", LOGLEVEL_ERROR);
             s.setLogic(Logics.QF_LIA);
             s.declareFun("x", new Sort[0], s.sort("Int"));
             s.declareFun("y", new Sort[0], s.sort("Int"));


### PR DESCRIPTION
Starting with one of the newer versions, smtinterpol started to print logger output to command line.
@fhowar addressed this in 3690d3cb87eb85982dc81846e698b0f6ce64b696

But I still had smtsolver statements in my log, so I investigated it further. With smtinterpol version 2.5 controlling logging output is much more comfortable. So I recommend to adapt to the new release version. 